### PR TITLE
Added a namespace identification to the with-designators call 

### DIFF
--- a/cram_beginner_tutorial/src/tutorial.lisp
+++ b/cram_beginner_tutorial/src/tutorial.lisp
@@ -167,7 +167,7 @@ $ rosrun turtle_actionlib shape_server"
     (with-turtle-process-modules
       (cpm:process-module-alias :manipulation 'turtle-actuators)
       (top-level
-        (with-designators
+        (cram-language-designator-support:with-designators
            ((trajectory (action '((type shape) (shape hexagon))))
             (loc (location '((type navigation) (vpos top) (hpos center)))))
           (cpm:pm-execute :manipulation trajectory))))))


### PR DESCRIPTION
Fixed call in in tutorial.lisp for the beginner tutorial to now include namespace identification. As per Gaya's advice, avoided a new uses line in packages.lisp since only one call to with-designators happens and a uses doesn't save much space but prevents readability.
